### PR TITLE
:sparkles: use default name when index-name is not given

### DIFF
--- a/database/mysql_client.go
+++ b/database/mysql_client.go
@@ -235,7 +235,10 @@ func (db *MySQLClient) buildCreateTableStmtIndex(cfg *config.Index) string {
 		sb.WriteString("    INDEX ")
 	}
 
-	sb.WriteString(cfg.Name)
+	if cfg.Name != "" {
+		sb.WriteString(cfg.Name)
+	}
+
 	sb.WriteString(" (")
 
 	var reg []string

--- a/examples/minimal_from_create_table.yaml
+++ b/examples/minimal_from_create_table.yaml
@@ -30,12 +30,10 @@ tables:
       type: decimal
       nullable: true
   indexes:
-    - name: index_1_on_table_a
-      uniq: true
+    - uniq: true
       columns:
         - col_2
-    - name: index_2_on_table_a
-      columns:
+    - columns:
         - col_3
         - col_4
   charset: utf8mb4
@@ -61,12 +59,10 @@ tables:
       order: 65535
       nullable: true
   indexes:
-    - name: index_1_on_table_b
-      uniq: true
+    - uniq: true
       columns:
         - col_2
-    - name: index_2_on_table_b
-      uniq: true
+    - uniq: true
       columns:
         - col_3
   charset: utf8mb4


### PR DESCRIPTION
# Summary
Make index-name skippable.
I think there isn't any reasons wanna designate index-name when people want to inspect sql query.