### PR TITLE
:recycle: rename attr nullable into notNull

### DIFF
--- a/cmd/root_test.go
+++ b/cmd/root_test.go
@@ -55,10 +55,6 @@ func Test_LoadConfig_Driver(t *testing.T) {
                       type: float
                       order: 5
                       precision: 2
-                      unsigned: true
-                      nullable: true
-                      default: 123.45
-                      primary: true
                   indexes:
                     - name: index_1_on_table_a
                       uniq: true
@@ -88,10 +84,6 @@ func Test_LoadConfig_Driver(t *testing.T) {
                       type: float
                       order: 5
                       precision: 2
-                      unsigned: true
-                      nullable: true
-                      default: 123.45
-                      primary: true
                   indexes:
                     - name: index_1_on_table_a
                       uniq: true
@@ -120,10 +112,6 @@ func Test_LoadConfig_Driver(t *testing.T) {
                       type: float
                       order: 5
                       precision: 2
-                      unsigned: true
-                      nullable: true
-                      default: 123.45
-                      primary: true
                   indexes:
                     - name: index_1_on_table_a
                       uniq: true
@@ -184,10 +172,6 @@ func Test_LoadConfig_Database(t *testing.T) {
                       type: float
                       order: 5
                       precision: 2
-                      unsigned: true
-                      nullable: true
-                      default: 123.45
-                      primary: true
                   indexes:
                     - name: index_1_on_table_a
                       uniq: true
@@ -217,10 +201,6 @@ func Test_LoadConfig_Database(t *testing.T) {
                       type: float
                       order: 5
                       precision: 2
-                      unsigned: true
-                      nullable: true
-                      default: 123.45
-                      primary: true
                   indexes:
                     - name: index_1_on_table_a
                       uniq: true
@@ -249,10 +229,6 @@ func Test_LoadConfig_Database(t *testing.T) {
                       type: float
                       order: 5
                       precision: 2
-                      unsigned: true
-                      nullable: true
-                      default: 123.45
-                      primary: true
                   indexes:
                     - name: index_1_on_table_a
                       uniq: true
@@ -287,10 +263,6 @@ func Test_LoadConfig_Database(t *testing.T) {
                       type: float
                       order: 5
                       precision: 2
-                      unsigned: true
-                      nullable: true
-                      default: 123.45
-                      primary: true
                   indexes:
                     - name: index_1_on_table_a
                       uniq: true
@@ -325,10 +297,6 @@ func Test_LoadConfig_Database(t *testing.T) {
                       type: float
                       order: 5
                       precision: 2
-                      unsigned: true
-                      nullable: true
-                      default: 123.45
-                      primary: true
                   indexes:
                     - name: index_1_on_table_a
                       uniq: true
@@ -363,10 +331,6 @@ func Test_LoadConfig_Database(t *testing.T) {
                       type: float
                       order: 5
                       precision: 2
-                      unsigned: true
-                      nullable: true
-                      default: 123.45
-                      primary: true
                   indexes:
                     - name: index_1_on_table_a
                       uniq: true
@@ -401,10 +365,6 @@ func Test_LoadConfig_Database(t *testing.T) {
                       type: float
                       order: 5
                       precision: 2
-                      unsigned: true
-                      nullable: false
-                      default: 123.45
-                      primary: true
                   indexes:
                     - name: index_1_on_table_a
                       uniq: true
@@ -474,7 +434,7 @@ func Test_LoadConfig_Tables(t *testing.T) {
                       order: 5
                       precision: 2
                       unsigned: true
-                      nullable: true
+                      notNull: true
                       default: 123.45
                       primary: true
                       increment: true
@@ -496,7 +456,7 @@ func Test_LoadConfig_Tables(t *testing.T) {
 							Order:     5,
 							Precision: 2,
 							Unsigned:  true,
-							Nullable:  true,
+							NotNull:   true,
 							Default:   123.45,
 							Primary:   true,
 							Increment: true,
@@ -550,7 +510,7 @@ func Test_LoadConfig_Tables(t *testing.T) {
                       order: 5
                       precision: 2
                       unsigned: true
-                      nullable: true
+                      notNull: true
                       default: 123.45
                       primary: true
                       increment: true
@@ -572,7 +532,7 @@ func Test_LoadConfig_Tables(t *testing.T) {
 							Order:     5,
 							Precision: 2,
 							Unsigned:  true,
-							Nullable:  true,
+							NotNull:   true,
 							Default:   123.45,
 							Primary:   true,
 							Increment: true,
@@ -652,7 +612,7 @@ func Test_LoadConfig_Tables(t *testing.T) {
                       order: 5
                       precision: 2
                       unsigned: true
-                      nullable: true
+                      notNull: true
                       default: 123.45
                       primary: true
                       increment: true
@@ -669,7 +629,7 @@ func Test_LoadConfig_Tables(t *testing.T) {
 							Order:     5,
 							Precision: 2,
 							Unsigned:  true,
-							Nullable:  true,
+							NotNull:   true,
 							Default:   123.45,
 							Primary:   true,
 							Increment: true,
@@ -701,7 +661,7 @@ func Test_LoadConfig_Tables(t *testing.T) {
                       order: 5
                       precision: 2
                       unsigned: true
-                      nullable: true
+                      notNull: true
                       default: 123.45
                       primary: true
                       increment: true
@@ -722,7 +682,7 @@ func Test_LoadConfig_Tables(t *testing.T) {
 							Order:     5,
 							Precision: 2,
 							Unsigned:  true,
-							Nullable:  true,
+							NotNull:   true,
 							Default:   123.45,
 							Primary:   true,
 							Increment: true,
@@ -762,7 +722,7 @@ func Test_LoadConfig_Tables(t *testing.T) {
                       order: 5
                       precision: 2
                       unsigned: true
-                      nullable: true
+                      notNull: true
                       default: 123.45
                       primary: true
                       increment: true
@@ -783,7 +743,7 @@ func Test_LoadConfig_Tables(t *testing.T) {
 							Order:     5,
 							Precision: 2,
 							Unsigned:  true,
-							Nullable:  true,
+							NotNull:   true,
 							Default:   123.45,
 							Primary:   true,
 							Increment: true,
@@ -852,7 +812,7 @@ func Test_LoadConfig_Columns(t *testing.T) {
                       order: 5
                       precision: 2
                       unsigned: true
-                      nullable: true
+                      notNull: true
                       default: 123.45
                       primary: true
                       increment: true
@@ -874,7 +834,7 @@ func Test_LoadConfig_Columns(t *testing.T) {
 							Order:     5,
 							Precision: 2,
 							Unsigned:  true,
-							Nullable:  true,
+							NotNull:   true,
 							Default:   123.45,
 							Primary:   true,
 							Increment: true,
@@ -913,7 +873,7 @@ func Test_LoadConfig_Columns(t *testing.T) {
                       order: 5
                       precision: 2
                       unsigned: true
-                      nullable: true
+                      notNull: true
                       default: 123.45
                       primary: true
                       increment: true
@@ -935,7 +895,7 @@ func Test_LoadConfig_Columns(t *testing.T) {
 							Order:     5,
 							Precision: 2,
 							Unsigned:  true,
-							Nullable:  true,
+							NotNull:   true,
 							Default:   123.45,
 							Primary:   true,
 							Increment: true,
@@ -974,7 +934,7 @@ func Test_LoadConfig_Columns(t *testing.T) {
                       type: float
                       precision: 2
                       unsigned: true
-                      nullable: true
+                      notNull: true
                       default: 123.45
                       primary: true
                       increment: true
@@ -996,7 +956,7 @@ func Test_LoadConfig_Columns(t *testing.T) {
 							Order:     0,
 							Precision: 2,
 							Unsigned:  true,
-							Nullable:  true,
+							NotNull:   true,
 							Default:   123.45,
 							Primary:   true,
 							Increment: true,
@@ -1035,7 +995,7 @@ func Test_LoadConfig_Columns(t *testing.T) {
                       type: float
                       order: 5
                       unsigned: true
-                      nullable: true
+                      notNull: true
                       default: 123.45
                       primary: true
                       increment: true
@@ -1057,7 +1017,7 @@ func Test_LoadConfig_Columns(t *testing.T) {
 							Order:     5,
 							Precision: 0,
 							Unsigned:  true,
-							Nullable:  true,
+							NotNull:   true,
 							Default:   123.45,
 							Primary:   true,
 							Increment: true,
@@ -1096,7 +1056,7 @@ func Test_LoadConfig_Columns(t *testing.T) {
                       type: float
                       order: 5
                       precision: 2
-                      nullable: true
+                      notNull: true
                       default: 123.45
                       primary: true
                       increment: true
@@ -1118,7 +1078,7 @@ func Test_LoadConfig_Columns(t *testing.T) {
 							Order:     5,
 							Precision: 2,
 							Unsigned:  false,
-							Nullable:  true,
+							NotNull:   true,
 							Default:   123.45,
 							Primary:   true,
 							Increment: true,
@@ -1141,7 +1101,7 @@ func Test_LoadConfig_Columns(t *testing.T) {
 		},
 
 		{
-			name: "missing a nullable of column in columns part",
+			name: "missing a notNull of column in columns part",
 			yaml: []byte(`
                 driver: mysql
                 database:
@@ -1179,7 +1139,7 @@ func Test_LoadConfig_Columns(t *testing.T) {
 							Order:     5,
 							Precision: 2,
 							Unsigned:  true,
-							Nullable:  false,
+							NotNull:   false,
 							Default:   123.45,
 							Primary:   true,
 							Increment: true,
@@ -1219,7 +1179,7 @@ func Test_LoadConfig_Columns(t *testing.T) {
                       order: 5
                       precision: 2
                       unsigned: true
-                      nullable: true
+                      notNull: true
                       primary: true
                       increment: true
                   indexes:
@@ -1240,7 +1200,7 @@ func Test_LoadConfig_Columns(t *testing.T) {
 							Order:     5,
 							Precision: 2,
 							Unsigned:  true,
-							Nullable:  true,
+							NotNull:   true,
 							Default:   nil,
 							Primary:   true,
 							Increment: true,
@@ -1280,7 +1240,7 @@ func Test_LoadConfig_Columns(t *testing.T) {
                       order: 5
                       precision: 2
                       unsigned: true
-                      nullable: true
+                      notNull: true
                       default: 123.45
                       increment: true
                   indexes:
@@ -1301,7 +1261,7 @@ func Test_LoadConfig_Columns(t *testing.T) {
 							Order:     5,
 							Precision: 2,
 							Unsigned:  true,
-							Nullable:  true,
+							NotNull:   true,
 							Default:   123.45,
 							Primary:   false,
 							Increment: true,
@@ -1341,7 +1301,7 @@ func Test_LoadConfig_Columns(t *testing.T) {
                       order: 5
                       precision: 2
                       unsigned: true
-                      nullable: true
+                      notNull: true
                       default: 123.45
                       primary: true
                   indexes:
@@ -1362,7 +1322,7 @@ func Test_LoadConfig_Columns(t *testing.T) {
 							Order:     5,
 							Precision: 2,
 							Unsigned:  true,
-							Nullable:  true,
+							NotNull:   true,
 							Default:   123.45,
 							Primary:   true,
 							Increment: false,
@@ -1433,7 +1393,7 @@ func Test_LoadConfig_Indexes(t *testing.T) {
                       order: 5
                       precision: 2
                       unsigned: true
-                      nullable: true
+                      notNull: true
                       default: 123.45
                       primary: true
                       increment: true
@@ -1454,7 +1414,7 @@ func Test_LoadConfig_Indexes(t *testing.T) {
 							Order:     5,
 							Precision: 2,
 							Unsigned:  true,
-							Nullable:  true,
+							NotNull:   true,
 							Default:   123.45,
 							Primary:   true,
 							Increment: true,
@@ -1494,7 +1454,7 @@ func Test_LoadConfig_Indexes(t *testing.T) {
                       order: 5
                       precision: 2
                       unsigned: true
-                      nullable: true
+                      notNull: true
                       default: 123.45
                       primary: true
                       increment: true
@@ -1515,7 +1475,7 @@ func Test_LoadConfig_Indexes(t *testing.T) {
 							Order:     5,
 							Precision: 2,
 							Unsigned:  true,
-							Nullable:  true,
+							NotNull:   true,
 							Default:   123.45,
 							Primary:   true,
 							Increment: true,
@@ -1555,7 +1515,7 @@ func Test_LoadConfig_Indexes(t *testing.T) {
                       order: 5
                       precision: 2
                       unsigned: true
-                      nullable: true
+                      notNull: true
                       default: 123.45
                       primary: true
                       increment: true
@@ -1575,7 +1535,7 @@ func Test_LoadConfig_Indexes(t *testing.T) {
 							Order:     5,
 							Precision: 2,
 							Unsigned:  true,
-							Nullable:  true,
+							NotNull:   true,
 							Default:   123.45,
 							Primary:   true,
 							Increment: true,

--- a/config/config.go
+++ b/config/config.go
@@ -129,7 +129,7 @@ type Column struct {
 	Order     int
 	Precision int
 	Unsigned  bool
-	Nullable  bool
+	NotNull   bool
 	Default   interface{}
 	Primary   bool
 	Increment bool

--- a/database/mysql_client.go
+++ b/database/mysql_client.go
@@ -166,7 +166,7 @@ func (db *MySQLClient) buildCreateTableStmtColumn(cfg *config.Column) string {
 		sb.WriteString(" AUTO_INCREMENT")
 	}
 
-	if !cfg.Nullable {
+	if cfg.NotNull {
 		sb.WriteString(" NOT NULL")
 	}
 

--- a/database/mysql_client_test.go
+++ b/database/mysql_client_test.go
@@ -51,11 +51,6 @@ func Test_BuildCreateTableStmt_Columns(t *testing.T) {
                       type: boolean
                       order: 0
                       precision: 0
-                      unsigned: false
-                      nullable: true
-                      default:
-                      primary: false
-                      increment: false
                   charset: utf8mb4
                   record: 100000
             `),
@@ -81,7 +76,7 @@ func Test_BuildCreateTableStmt_Columns(t *testing.T) {
                       order: 0
                       precision: 0
                       unsigned: true
-                      nullable: false
+                      notNull: true
                       default: true
                       primary: true
                       increment: true
@@ -109,11 +104,6 @@ func Test_BuildCreateTableStmt_Columns(t *testing.T) {
                       type: tinyint
                       order: 4
                       precision: 0
-                      unsigned: false
-                      nullable: true
-                      default:
-                      primary: false
-                      increment: false
                   charset: utf8mb4
                   record: 100000
             `),
@@ -138,11 +128,6 @@ func Test_BuildCreateTableStmt_Columns(t *testing.T) {
                       type: smallint
                       order: 6
                       precision: 0
-                      unsigned: false
-                      nullable: true
-                      default:
-                      primary: false
-                      increment: false
                   charset: utf8mb4
                   record: 100000
             `),
@@ -167,11 +152,6 @@ func Test_BuildCreateTableStmt_Columns(t *testing.T) {
                       type: mediumint
                       order: 9
                       precision: 0
-                      unsigned: false
-                      nullable: true
-                      default:
-                      primary: false
-                      increment: false
                   charset: utf8mb4
                   record: 100000
             `),
@@ -196,11 +176,6 @@ func Test_BuildCreateTableStmt_Columns(t *testing.T) {
                       type: int
                       order: 11
                       precision: 0
-                      unsigned: false
-                      nullable: true
-                      default:
-                      primary: false
-                      increment: false
                   charset: utf8mb4
                   record: 100000
             `),
@@ -225,11 +200,6 @@ func Test_BuildCreateTableStmt_Columns(t *testing.T) {
                       type: bigint
                       order: 20
                       precision: 0
-                      unsigned: false
-                      nullable: true
-                      default:
-                      primary: false
-                      increment: false
                   charset: utf8mb4
                   record: 100000
             `),
@@ -255,7 +225,7 @@ func Test_BuildCreateTableStmt_Columns(t *testing.T) {
                       order: 20
                       precision: 0
                       unsigned: true
-                      nullable: false
+                      notNull: true
                       default: 1000
                       primary: true
                       increment: true
@@ -283,11 +253,6 @@ func Test_BuildCreateTableStmt_Columns(t *testing.T) {
                       type: decimal
                       order: 5
                       precision: 2
-                      unsigned: false
-                      nullable: true
-                      default:
-                      primary: false
-                      increment: false
                   charset: utf8mb4
                   record: 100000
             `),
@@ -312,11 +277,6 @@ func Test_BuildCreateTableStmt_Columns(t *testing.T) {
                       type: float
                       order: 5
                       precision: 2
-                      unsigned: false
-                      nullable: true
-                      default:
-                      primary: false
-                      increment: false
                   charset: utf8mb4
                   record: 100000
             `),
@@ -341,11 +301,6 @@ func Test_BuildCreateTableStmt_Columns(t *testing.T) {
                       type: real
                       order: 5
                       precision: 2
-                      unsigned: false
-                      nullable: true
-                      default:
-                      primary: false
-                      increment: false
                   charset: utf8mb4
                   record: 100000
             `),
@@ -370,11 +325,6 @@ func Test_BuildCreateTableStmt_Columns(t *testing.T) {
                       type: double
                       order: 5
                       precision: 2
-                      unsigned: false
-                      nullable: true
-                      default:
-                      primary: false
-                      increment: false
                   charset: utf8mb4
                   record: 100000
             `),
@@ -400,7 +350,7 @@ func Test_BuildCreateTableStmt_Columns(t *testing.T) {
                       order: 5
                       precision: 2
                       unsigned: true
-                      nullable: false
+                      notNull: true
                       default: 123.45
                       primary: true
                       increment: true
@@ -428,11 +378,6 @@ func Test_BuildCreateTableStmt_Columns(t *testing.T) {
                       type: bit
                       order: 8
                       precision: 0
-                      unsigned: false
-                      nullable: true
-                      default:
-                      primary: false
-                      increment: false
                   charset: utf8mb4
                   record: 100000
             `),
@@ -458,7 +403,7 @@ func Test_BuildCreateTableStmt_Columns(t *testing.T) {
                       order: 8
                       precision: 0
                       unsigned: true
-                      nullable: false
+                      notNull: true
                       default: b'01010101'
                       primary: true
                       increment: true
@@ -486,11 +431,6 @@ func Test_BuildCreateTableStmt_Columns(t *testing.T) {
                       type: date
                       order: 0
                       precision: 0
-                      unsigned: false
-                      nullable: true
-                      default:
-                      primary: false
-                      increment: false
                   charset: utf8mb4
                   record: 100000
             `),
@@ -515,11 +455,6 @@ func Test_BuildCreateTableStmt_Columns(t *testing.T) {
                       type: datetime
                       order: 0
                       precision: 0
-                      unsigned: false
-                      nullable: true
-                      default:
-                      primary: false
-                      increment: false
                   charset: utf8mb4
                   record: 100000
             `),
@@ -544,11 +479,6 @@ func Test_BuildCreateTableStmt_Columns(t *testing.T) {
                       type: timestamp
                       order: 0
                       precision: 0
-                      unsigned: false
-                      nullable: true
-                      default:
-                      primary: false
-                      increment: false
                   charset: utf8mb4
                   record: 100000
             `),
@@ -573,11 +503,6 @@ func Test_BuildCreateTableStmt_Columns(t *testing.T) {
                       type: time
                       order: 0
                       precision: 0
-                      unsigned: false
-                      nullable: true
-                      default:
-                      primary: false
-                      increment: false
                   charset: utf8mb4
                   record: 100000
             `),
@@ -602,11 +527,6 @@ func Test_BuildCreateTableStmt_Columns(t *testing.T) {
                       type: year
                       order: 4
                       precision: 0
-                      unsigned: false
-                      nullable: true
-                      default:
-                      primary: false
-                      increment: false
                   charset: utf8mb4
                   record: 100000
             `),
@@ -632,7 +552,7 @@ func Test_BuildCreateTableStmt_Columns(t *testing.T) {
                       order: 0
                       precision: 0
                       unsigned: true
-                      nullable: false
+                      notNull: true
                       default: 2000-12-01
                       primary: true
                       increment: true
@@ -660,11 +580,6 @@ func Test_BuildCreateTableStmt_Columns(t *testing.T) {
                       type: char
                       order: 20
                       precision: 0
-                      unsigned: false
-                      nullable: true
-                      default:
-                      primary: false
-                      increment: false
                   charset: utf8mb4
                   record: 100000
             `),
@@ -689,11 +604,6 @@ func Test_BuildCreateTableStmt_Columns(t *testing.T) {
                       type: varchar
                       order: 20
                       precision: 0
-                      unsigned: false
-                      nullable: true
-                      default:
-                      primary: false
-                      increment: false
                   charset: utf8mb4
                   record: 100000
             `),
@@ -718,11 +628,6 @@ func Test_BuildCreateTableStmt_Columns(t *testing.T) {
                       type: binary
                       order: 20
                       precision: 0
-                      unsigned: false
-                      nullable: true
-                      default:
-                      primary: false
-                      increment: false
                   charset: utf8mb4
                   record: 100000
             `),
@@ -747,11 +652,6 @@ func Test_BuildCreateTableStmt_Columns(t *testing.T) {
                       type: varbinary
                       order: 20
                       precision: 0
-                      unsigned: false
-                      nullable: true
-                      default:
-                      primary: false
-                      increment: false
                   charset: utf8mb4
                   record: 100000
             `),
@@ -776,11 +676,6 @@ func Test_BuildCreateTableStmt_Columns(t *testing.T) {
                       type: tinyblob
                       order: 0
                       precision: 0
-                      unsigned: false
-                      nullable: true
-                      default:
-                      primary: false
-                      increment: false
                   charset: utf8mb4
                   record: 100000
             `),
@@ -805,11 +700,6 @@ func Test_BuildCreateTableStmt_Columns(t *testing.T) {
                       type: tinytext
                       order: 0
                       precision: 0
-                      unsigned: false
-                      nullable: true
-                      default:
-                      primary: false
-                      increment: false
                   charset: utf8mb4
                   record: 100000
             `),
@@ -834,11 +724,6 @@ func Test_BuildCreateTableStmt_Columns(t *testing.T) {
                       type: blob
                       order: 65535
                       precision: 0
-                      unsigned: false
-                      nullable: true
-                      default:
-                      primary: false
-                      increment: false
                   charset: utf8mb4
                   record: 100000
             `),
@@ -863,11 +748,6 @@ func Test_BuildCreateTableStmt_Columns(t *testing.T) {
                       type: text
                       order: 65535
                       precision: 0
-                      unsigned: false
-                      nullable: true
-                      default:
-                      primary: false
-                      increment: false
                   charset: utf8mb4
                   record: 100000
             `),
@@ -892,11 +772,6 @@ func Test_BuildCreateTableStmt_Columns(t *testing.T) {
                       type: mediumblob
                       order: 0
                       precision: 0
-                      unsigned: false
-                      nullable: true
-                      default:
-                      primary: false
-                      increment: false
                   charset: utf8mb4
                   record: 100000
             `),
@@ -921,11 +796,6 @@ func Test_BuildCreateTableStmt_Columns(t *testing.T) {
                       type: mediumtext
                       order: 0
                       precision: 0
-                      unsigned: false
-                      nullable: true
-                      default:
-                      primary: false
-                      increment: false
                   charset: utf8mb4
                   record: 100000
             `),
@@ -950,11 +820,6 @@ func Test_BuildCreateTableStmt_Columns(t *testing.T) {
                       type: longblob
                       order: 0
                       precision: 0
-                      unsigned: false
-                      nullable: true
-                      default:
-                      primary: false
-                      increment: false
                   charset: utf8mb4
                   record: 100000
             `),
@@ -979,11 +844,6 @@ func Test_BuildCreateTableStmt_Columns(t *testing.T) {
                       type: longtext
                       order: 0
                       precision: 0
-                      unsigned: false
-                      nullable: true
-                      default:
-                      primary: false
-                      increment: false
                   charset: utf8mb4
                   record: 100000
             `),
@@ -1009,7 +869,7 @@ func Test_BuildCreateTableStmt_Columns(t *testing.T) {
                       order: 65535
                       precision: 0
                       unsigned: true
-                      nullable: false
+                      notNull: true
                       default: "hoge"
                       primary: true
                       increment: true
@@ -1071,11 +931,6 @@ func Test_BuildOrderDesc(t *testing.T) {
                       type: tinyint
                       order:
                       precision:
-                      unsigned: false
-                      nullable: true
-                      default:
-                      primary: false
-                      increment: false
                   charset: utf8mb4
                   record: 100000
             `),
@@ -1100,11 +955,6 @@ func Test_BuildOrderDesc(t *testing.T) {
                       type: tinyint
                       order: 2
                       precision:
-                      unsigned: false
-                      nullable: true
-                      default:
-                      primary: false
-                      increment: false
                   charset: utf8mb4
                   record: 100000
             `),
@@ -1129,11 +979,6 @@ func Test_BuildOrderDesc(t *testing.T) {
                       type: smallint
                       order:
                       precision:
-                      unsigned: false
-                      nullable: true
-                      default:
-                      primary: false
-                      increment: false
                   charset: utf8mb4
                   record: 100000
             `),
@@ -1158,11 +1003,6 @@ func Test_BuildOrderDesc(t *testing.T) {
                       type: smallint
                       order: 4
                       precision:
-                      unsigned: false
-                      nullable: true
-                      default:
-                      primary: false
-                      increment: false
                   charset: utf8mb4
                   record: 100000
             `),
@@ -1187,11 +1027,6 @@ func Test_BuildOrderDesc(t *testing.T) {
                       type: mediumint
                       order:
                       precision:
-                      unsigned: false
-                      nullable: true
-                      default:
-                      primary: false
-                      increment: false
                   charset: utf8mb4
                   record: 100000
             `),
@@ -1216,11 +1051,6 @@ func Test_BuildOrderDesc(t *testing.T) {
                       type: mediumint
                       order: 6
                       precision:
-                      unsigned: false
-                      nullable: true
-                      default:
-                      primary: false
-                      increment: false
                   charset: utf8mb4
                   record: 100000
             `),
@@ -1245,11 +1075,6 @@ func Test_BuildOrderDesc(t *testing.T) {
                       type: int
                       order:
                       precision:
-                      unsigned: false
-                      nullable: true
-                      default:
-                      primary: false
-                      increment: false
                   charset: utf8mb4
                   record: 100000
             `),
@@ -1274,11 +1099,6 @@ func Test_BuildOrderDesc(t *testing.T) {
                       type: int
                       order: 9
                       precision:
-                      unsigned: false
-                      nullable: true
-                      default:
-                      primary: false
-                      increment: false
                   charset: utf8mb4
                   record: 100000
             `),
@@ -1303,11 +1123,6 @@ func Test_BuildOrderDesc(t *testing.T) {
                       type: bigint
                       order:
                       precision:
-                      unsigned: false
-                      nullable: true
-                      default:
-                      primary: false
-                      increment: false
                   charset: utf8mb4
                   record: 100000
             `),
@@ -1332,11 +1147,6 @@ func Test_BuildOrderDesc(t *testing.T) {
                       type: bigint
                       order: 11
                       precision:
-                      unsigned: false
-                      nullable: true
-                      default:
-                      primary: false
-                      increment: false
                   charset: utf8mb4
                   record: 100000
             `),
@@ -1361,11 +1171,6 @@ func Test_BuildOrderDesc(t *testing.T) {
                       type: bit
                       order:
                       precision:
-                      unsigned: false
-                      nullable: true
-                      default:
-                      primary: false
-                      increment: false
                   charset: utf8mb4
                   record: 100000
             `),
@@ -1390,11 +1195,6 @@ func Test_BuildOrderDesc(t *testing.T) {
                       type: bit
                       order: 8
                       precision:
-                      unsigned: false
-                      nullable: true
-                      default:
-                      primary: false
-                      increment: false
                   charset: utf8mb4
                   record: 100000
             `),
@@ -1419,11 +1219,6 @@ func Test_BuildOrderDesc(t *testing.T) {
                       type: varchar
                       order:
                       precision:
-                      unsigned: false
-                      nullable: true
-                      default:
-                      primary: false
-                      increment: false
                   charset: utf8mb4
                   record: 100000
             `),
@@ -1448,11 +1243,6 @@ func Test_BuildOrderDesc(t *testing.T) {
                       type: varchar
                       order: 8
                       precision:
-                      unsigned: false
-                      nullable: true
-                      default:
-                      primary: false
-                      increment: false
                   charset: utf8mb4
                   record: 100000
             `),
@@ -1513,11 +1303,6 @@ func Test_BuildPrecisionDesc(t *testing.T) {
                       type: decimal
                       order:
                       precision:
-                      unsigned: false
-                      nullable: true
-                      default:
-                      primary: false
-                      increment: false
                   charset: utf8mb4
                   record: 100000
             `),
@@ -1542,11 +1327,6 @@ func Test_BuildPrecisionDesc(t *testing.T) {
                       type: decimal
                       order: 6
                       precision: 3
-                      unsigned: false
-                      nullable: true
-                      default:
-                      primary: false
-                      increment: false
                   charset: utf8mb4
                   record: 100000
             `),
@@ -1571,11 +1351,6 @@ func Test_BuildPrecisionDesc(t *testing.T) {
                       type: float
                       order:
                       precision:
-                      unsigned: false
-                      nullable: true
-                      default:
-                      primary: false
-                      increment: false
                   charset: utf8mb4
                   record: 100000
             `),
@@ -1600,11 +1375,6 @@ func Test_BuildPrecisionDesc(t *testing.T) {
                       type: float
                       order: 6
                       precision: 3
-                      unsigned: false
-                      nullable: true
-                      default:
-                      primary: false
-                      increment: false
                   charset: utf8mb4
                   record: 100000
             `),
@@ -1665,11 +1435,7 @@ func Test_BuildDefaultDesc(t *testing.T) {
                       type: varchar
                       order:
                       precision:
-                      unsigned: false
-                      nullable: true
                       default: hoge
-                      primary: false
-                      increment: false
                   charset: utf8mb4
                   record: 100000
             `),
@@ -1694,11 +1460,7 @@ func Test_BuildDefaultDesc(t *testing.T) {
                       type: decimal
                       order: 6
                       precision: 3
-                      unsigned: false
-                      nullable: true
                       default: 123.456
-                      primary: false
-                      increment: false
                   charset: utf8mb4
                   record: 100000
             `),
@@ -1759,11 +1521,6 @@ func Test_BuildDropTableStmt(t *testing.T) {
                       type: boolean
                       order: 0
                       precision: 0
-                      unsigned: false
-                      nullable: true
-                      default:
-                      primary: false
-                      increment: false
                   charset: utf8mb4
                   record: 100000
             `),

--- a/examples/from_create_table.yaml
+++ b/examples/from_create_table.yaml
@@ -13,7 +13,7 @@ tables:
       order: 20
       precision:
       unsigned: true
-      nullable: false
+      notNUll: true
       default:
       primary: true
       increment: true
@@ -22,7 +22,7 @@ tables:
       order: 50
       precision:
       unsigned: false
-      nullable: true
+      notNUll: false
       default:
       primary: false
       increment: false
@@ -31,7 +31,7 @@ tables:
       order:
       precision: true
       unsigned: false
-      nullable: true
+      notNUll: false
       default:
       primary: false
       increment: false
@@ -40,7 +40,7 @@ tables:
       order: 5
       precision: 3
       unsigned: false
-      nullable: true
+      notNUll: true
       default:
       primary: false
       increment: false
@@ -49,7 +49,7 @@ tables:
       order: 5
       precision: 3
       unsigned: false
-      nullable: true
+      notNUll: true
       default:
       primary: false
       increment: false
@@ -72,7 +72,7 @@ tables:
       order: 11
       precision:
       unsigned: true
-      nullable: false
+      notNUll: true
       default:
       primary: true
       increment: true
@@ -81,7 +81,7 @@ tables:
       order:
       precision:
       unsigned: false
-      nullable: true
+      notNUll: false
       default:
       primary: false
       increment: false
@@ -90,7 +90,7 @@ tables:
       order: 20
       precision:
       unsigned: false
-      nullable: false
+      notNUll: true
       default: ""
       primary: false
       increment: false
@@ -99,7 +99,7 @@ tables:
       order: 65535
       precision:
       unsigned: false
-      nullable: true
+      notNUll: false
       default:
       primary: false
       increment: false

--- a/examples/minimal_from_create_table.yaml
+++ b/examples/minimal_from_create_table.yaml
@@ -16,19 +16,19 @@ tables:
     - name: col_2
       type: varchar
       order: 50
-      nullable: true
+      notNull: true
     - name: col_3
       type: boolean
       precision: true
-      nullable: true
+      notNull: true
     - name: col_4
       type: float
       order: 5
       precision: 3
-      nullable: true
+      notNull: true
     - name: col_5
       type: decimal
-      nullable: true
+      notNull: true
   indexes:
     - uniq: true
       columns:
@@ -47,7 +47,7 @@ tables:
       increment: true
     - name: col_2
       type: datetime
-      nullable: true
+      notNull: true
     - name: col_3
       type: varchar
       order: 20
@@ -57,7 +57,7 @@ tables:
     - name: col_4
       type: blob
       order: 65535
-      nullable: true
+      notNull: true
   indexes:
     - uniq: true
       columns:


### PR DESCRIPTION
# Summary
When Yaml input is not given, boolean attrs are set false as zero-value.
In that context, nullable attr gives not-null constraint by its zero-value.
Obviously, that is not preferable.

So, change it into notNull. notNull's zero-value doesn't give not-null constraint as same as other attrs.