### PR TITLE
:sparkles: Unofficial default orders

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,183 @@ $ go get github.com/terakoya76/populator
 ```
 
 ## How to use
+You need to prepare config file, then run below command.
+
+```shell
+$ populator -c ./path/to/configfile.yaml
+```
+
+### Config
+This is full type of config file. You can add tables, columns, indexes as many as you want.
+
+```yaml
+driver: mysql
+database:
+  host: 127.0.0.1
+  user: root
+  password: root
+  name: testdb
+  port: 3306
+tables:
+- name: table_a
+  columns:
+    - name: col_1
+      type: bigint
+      order: 20
+      precision:
+      unsigned: true
+      notNUll: true
+      default:
+      primary: true
+      autoIncrement: true
+      values:
+    - name: col_2
+      type: varchar
+      order: 50
+      precision:
+      unsigned: false
+      notNUll: false
+      default:
+      primary: false
+      autoIncrement: false
+      values:
+  indexes:
+    - name: index_1_on_table_a
+      uniq: true
+      columns:
+        - col_2
+  charset: utf8mb4
+  record: 100000
+```
+
+#### Driver
+Choose rdb driver for database you want to populate.
+
+```
+driver: mysql
+```
+
+Currently only supports below RDBMS
+
+- MySQL
+
+#### Database
+```yaml
+database:
+  host: 127.0.0.1
+  user: root
+  password: root
+  name: testdb
+  port: 3306
+```
+
+#### Tables
+If the table w/ designated name is not existed, this tool create table firstly. This is executed by `CREATE TABLE IF NOT EXIST` statment, so charset is required.
+
+Record is a number that how many records you want to insert to this table.
+
+```yaml
+tables:
+- name: table_a
+  columns:
+    - name: col_1
+      type: bigint
+      order: 20
+      precision:
+      unsigned: true
+      notNUll: true
+      default:
+      primary: true
+      autoIncrement: true
+      values:
+    - name: col_2
+      type: varchar
+      order: 50
+      precision:
+      unsigned: false
+      notNUll: false
+      default:
+      primary: false
+      autoIncrement: false
+      values:
+  indexes:
+    - name: index_1_on_table_a
+      uniq: true
+      columns:
+        - col_2
+  charset: utf8mb4
+  record: 100000
+```
+
+#### Columns
+Column represents what kind of columns should be held by the table. This only works when table is not existed.
+
+If you want to enable option like unsigned, notNull and so on, you need to set true flag. If non-support option is set to true like varchar w/ unsigned, that option is just ignored.
+
+```yaml
+  columns:
+    - name: col_1
+      type: bigint
+      order: 20
+      precision:
+      unsigned: true
+      notNUll: true
+      default:
+      primary: true
+      autoIncrement: true
+      values:
+```
+
+Some of options are not required. This is a minimal description.
+
+```yaml
+  columns:
+    - name: col_1
+      type: bigint
+```
+
+When you don't give order/precision to data-type rquiring them like int(x), varchar(x), the default values are used. The default valeus are basically based on rdb default (int's default order is 11). Also we support unofficial default order/precision for rest of data-types like varchar, float and so on. So if your focus is not on the order/precision, you don't need to describe them.
+
+Also we support concrete value constraint by values. From below declaration, col_1 would be populated w/ only "YES", "NO".
+
+```yaml
+  columns:
+    - name: col_1
+      type: varchar
+      values:
+        - "YES"
+        - "NO"
+```
+
+#### Indexes
+Index represents what kind of indexes should be held by the table. This only works when table is not existed.
+
+```yaml
+  indexes:
+    - name: index_1_on_table_a
+      uniq: true
+      columns:
+        - col_2
+```
+
+Some of options are not required. This is a minimal description.
+
+```yaml
+  indexes:
+    - columns:
+        - col_2
+```
+
+When you want to use covering index, you can describe like below.
+
+```yaml
+  indexes:
+    - columns:
+        - col_1
+        - col_2
+```
+
+### Examples
 There're sample config files, you can try it.
 
 when you haven't setup the database or tables yet
@@ -32,8 +209,3 @@ when you want to re-create table schema w/ given declarations
 ```shell
 $ populator -rc ./examples/from_create_table.yaml
 ```
-
-## Support RDBMS
-Currently only supports below RDBMS
-
-- MySQL

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -129,5 +129,5 @@ func LoadConfig() error {
 		return err
 	}
 
-	return config.Instance.IsValid()
+	return config.Instance.Validate()
 }

--- a/config/config.go
+++ b/config/config.go
@@ -30,12 +30,23 @@ type config struct {
 	Tables   []*Table
 }
 
-func (c *config) IsValid() error {
-	if err := c.Driver.isValid(); err != nil {
+// CompleteWithDefault complete config value which is not required but configurable
+func (c *config) CompleteWithDefault() {
+	c.Driver.CompleteWithDefault()
+	c.Database.CompleteWithDefault()
+	for _, table := range c.Tables {
+		table.CompleteWithDefault()
+	}
+
+}
+
+// Validate validates config
+func (c *config) Validate() error {
+	if err := c.Driver.Validate(); err != nil {
 		return err
 	}
 
-	if err := c.Database.isValid(); err != nil {
+	if err := c.Database.Validate(); err != nil {
 		return err
 	}
 
@@ -43,7 +54,7 @@ func (c *config) IsValid() error {
 		return errors.New("tables definition is required")
 	}
 	for _, table := range c.Tables {
-		if err := table.isValid(); err != nil {
+		if err := table.Validate(); err != nil {
 			return err
 		}
 	}
@@ -51,15 +62,15 @@ func (c *config) IsValid() error {
 	return nil
 }
 
-// CompleteWithDefault complete config value which is not required but configurable
-func (c *config) CompleteWithDefault() {
-	c.Database.completeWithDefault()
-}
-
 // Driver represents database driver
 type Driver string
 
-func (d Driver) isValid() error {
+// CompleteWithDefault complete config value which is not required but configurable
+func (d *Driver) CompleteWithDefault() {
+}
+
+// Validate validates database driver config
+func (d Driver) Validate() error {
 	// TODO: adopt more
 	switch d {
 	case "mysql":
@@ -78,7 +89,8 @@ type Database struct {
 	Name     string
 }
 
-func (db *Database) isValid() error {
+// Validate validates database config
+func (db *Database) Validate() error {
 	if db == nil {
 		return errors.New("database connection information is required")
 	}
@@ -94,51 +106,12 @@ func (db *Database) isValid() error {
 	return nil
 }
 
-func (db *Database) completeWithDefault() {
+// CompleteWithDefault complete config value which is not required but configurable
+func (db *Database) CompleteWithDefault() {
 	if db.Host == "" {
 		db.Host = "127.0.0.1"
 	}
 	if db.Port == 0 {
 		db.Port = 3306
 	}
-}
-
-// Table represents a single table schema
-type Table struct {
-	Name    string
-	Columns []*Column
-	Indexes []*Index
-	Charset string
-	Record  int
-}
-
-func (t *Table) isValid() error {
-	if t == nil {
-		return errors.New("table definition is invalid")
-	}
-	if t.Name == "" {
-		return errors.New("table name is required")
-	}
-	return nil
-}
-
-// Column represents a single column schema
-type Column struct {
-	Name          string
-	Type          string
-	Order         int
-	Precision     int
-	Unsigned      bool
-	NotNull       bool
-	Default       interface{}
-	Primary       bool
-	AutoIncrement bool
-	Values        []interface{}
-}
-
-// Index represents a single index schema
-type Index struct {
-	Name    string
-	Uniq    bool
-	Columns []string
 }

--- a/config/table.go
+++ b/config/table.go
@@ -67,6 +67,65 @@ type Column struct {
 
 // CompleteWithDefault complete config value which is not required but configurable
 func (c *Column) CompleteWithDefault() {
+	if c.Order == 0 {
+		switch c.Type {
+		case "tinyint":
+			c.Order = 4
+		case "smallint":
+			c.Order = 6
+		case "mediumint":
+			c.Order = 9
+		case "int":
+			c.Order = 11
+		case "bigint":
+			c.Order = 20
+		case "bit":
+			c.Order = 1
+		case "blob":
+			// Unofficial Value
+			c.Order = 65535
+		case "text":
+			// Unofficial Value
+			c.Order = 65535
+		case "year":
+			// Unofficial Value
+			c.Order = 4
+		case "char":
+			// Unofficial Value
+			c.Order = 255
+		case "varchar":
+			// Unofficial Value
+			c.Order = 255
+		case "binary":
+			// Unofficial Value
+			c.Order = 255
+		case "varbinary":
+			// Unofficial Value
+			c.Order = 255
+		default:
+		}
+	}
+
+	if c.Order == 0 && c.Precision == 0 {
+		switch c.Type {
+		case "decimal":
+			c.Order = 10
+			c.Precision = 0
+		case "float":
+			// Unofficial Value
+			c.Order = 5
+			c.Precision = 2
+		case "real":
+			// Unofficial Value
+			c.Order = 5
+			c.Precision = 10
+		case "double":
+			// Unofficial Value
+			c.Order = 5
+			c.Precision = 10
+		default:
+		}
+	}
 }
 
 // Validate validates column config

--- a/config/table.go
+++ b/config/table.go
@@ -1,0 +1,91 @@
+/*
+Package config ...
+
+Copyright © 2019 hajime-terasawa <terako.studio@gmail.com>
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+package config
+
+import (
+	"errors"
+)
+
+// Table represents a single table schema
+type Table struct {
+	Name    string
+	Columns []*Column
+	Indexes []*Index
+	Charset string
+	Record  int
+}
+
+// CompleteWithDefault complete config value which is not required but configurable
+func (t *Table) CompleteWithDefault() {
+	for _, column := range t.Columns {
+		column.CompleteWithDefault()
+	}
+	for _, index := range t.Indexes {
+		index.CompleteWithDefault()
+	}
+}
+
+// Validate validates table config
+func (t *Table) Validate() error {
+	if t == nil {
+		return errors.New("table definition is invalid")
+	}
+	if t.Name == "" {
+		return errors.New("table name is required")
+	}
+	return nil
+}
+
+// Column represents a single column schema
+type Column struct {
+	Name          string
+	Type          string
+	Order         int
+	Precision     int
+	Unsigned      bool
+	NotNull       bool
+	Default       interface{}
+	Primary       bool
+	AutoIncrement bool
+	Values        []interface{}
+}
+
+// CompleteWithDefault complete config value which is not required but configurable
+func (c *Column) CompleteWithDefault() {
+}
+
+// Validate validates column config
+func (c *Column) Validate() error {
+	return nil
+}
+
+// Index represents a single index schema
+type Index struct {
+	Name    string
+	Uniq    bool
+	Columns []string
+}
+
+// CompleteWithDefault complete config value which is not required but configurable
+func (i *Index) CompleteWithDefault() {
+}
+
+// Validate validates index config
+func (i *Index) Validate() error {
+	return nil
+}

--- a/database/mysql_client.go
+++ b/database/mysql_client.go
@@ -151,11 +151,11 @@ func (db *MySQLClient) buildCreateTableStmtColumn(cfg *config.Column) string {
 	)
 
 	if utils.Contains(OrderRequiredDataTypes, cfg.Type) {
-		sb.WriteString(db.BuildOrderDesc(cfg))
+		sb.WriteString(fmt.Sprintf("(%d)", cfg.Order))
 	}
 
 	if utils.Contains(PrecisionRequiredDataTypes, cfg.Type) {
-		sb.WriteString(db.BuildPrecisionDesc(cfg))
+		sb.WriteString(fmt.Sprintf("(%d, %d)", cfg.Order, cfg.Precision))
 	}
 
 	if utils.Contains(UnsignedableDataType, cfg.Type) && cfg.Unsigned {
@@ -179,42 +179,6 @@ func (db *MySQLClient) buildCreateTableStmtColumn(cfg *config.Column) string {
 	}
 
 	return sb.String()
-}
-
-// BuildOrderDesc generate a order desc part of sql for MySQL
-func (db *MySQLClient) BuildOrderDesc(cfg *config.Column) string {
-	if cfg.Order > 0 {
-		return fmt.Sprintf("(%d)", cfg.Order)
-	}
-	switch cfg.Type {
-	case "tinyint":
-		return fmt.Sprintf("(%d)", 4)
-	case "smallint":
-		return fmt.Sprintf("(%d)", 6)
-	case "mediumint":
-		return fmt.Sprintf("(%d)", 9)
-	case "int":
-		return fmt.Sprintf("(%d)", 11)
-	case "bigint":
-		return fmt.Sprintf("(%d)", 20)
-	case "bit":
-		return fmt.Sprintf("(%d)", 1)
-	default:
-		return fmt.Sprintf("(%d)", cfg.Order)
-	}
-}
-
-// BuildPrecisionDesc generate a order/precision desc part of sql for MySQL
-func (db *MySQLClient) BuildPrecisionDesc(cfg *config.Column) string {
-	if cfg.Order > 0 && cfg.Precision > 0 {
-		return fmt.Sprintf("(%d, %d)", cfg.Order, cfg.Precision)
-	}
-	switch cfg.Type {
-	case "decimal":
-		return fmt.Sprintf("(%d, %d)", 10, 0)
-	default:
-		return fmt.Sprintf("(%d, %d)", cfg.Order, cfg.Precision)
-	}
 }
 
 // BuildDefaultDesc generate a default desc part of sql for MySQL

--- a/database/mysql_client_test.go
+++ b/database/mysql_client_test.go
@@ -93,7 +93,7 @@ func Test_BuildCreateTableStmt_Columns(t *testing.T) {
 					{
 						Name:          "col_1",
 						Type:          "tinyint",
-						Order:         0,
+						Order:         2,
 						Precision:     0,
 						Unsigned:      false,
 						NotNull:       false,
@@ -107,19 +107,19 @@ func Test_BuildCreateTableStmt_Columns(t *testing.T) {
 				Charset: "utf8mb4",
 				Record:  100000,
 			},
-			sql: "CREATE TABLE IF NOT EXISTS table_a (\n    col_1 tinyint(4)\n) DEFAULT CHARSET=utf8mb4",
+			sql: "CREATE TABLE IF NOT EXISTS table_a (\n    col_1 tinyint(2)\n) DEFAULT CHARSET=utf8mb4",
 			err: nil,
 		},
 
 		{
-			name: "smallint(6)",
+			name: "smallint",
 			cfg: &config.Table{
 				Name: "table_a",
 				Columns: []*config.Column{
 					{
 						Name:          "col_1",
 						Type:          "smallint",
-						Order:         0,
+						Order:         4,
 						Precision:     0,
 						Unsigned:      false,
 						NotNull:       false,
@@ -133,19 +133,19 @@ func Test_BuildCreateTableStmt_Columns(t *testing.T) {
 				Charset: "utf8mb4",
 				Record:  100000,
 			},
-			sql: "CREATE TABLE IF NOT EXISTS table_a (\n    col_1 smallint(6)\n) DEFAULT CHARSET=utf8mb4",
+			sql: "CREATE TABLE IF NOT EXISTS table_a (\n    col_1 smallint(4)\n) DEFAULT CHARSET=utf8mb4",
 			err: nil,
 		},
 
 		{
-			name: "mediumint(9)",
+			name: "mediumint",
 			cfg: &config.Table{
 				Name: "table_a",
 				Columns: []*config.Column{
 					{
 						Name:          "col_1",
 						Type:          "mediumint",
-						Order:         0,
+						Order:         6,
 						Precision:     0,
 						Unsigned:      false,
 						NotNull:       false,
@@ -159,19 +159,19 @@ func Test_BuildCreateTableStmt_Columns(t *testing.T) {
 				Charset: "utf8mb4",
 				Record:  100000,
 			},
-			sql: "CREATE TABLE IF NOT EXISTS table_a (\n    col_1 mediumint(9)\n) DEFAULT CHARSET=utf8mb4",
+			sql: "CREATE TABLE IF NOT EXISTS table_a (\n    col_1 mediumint(6)\n) DEFAULT CHARSET=utf8mb4",
 			err: nil,
 		},
 
 		{
-			name: "int(11)",
+			name: "int",
 			cfg: &config.Table{
 				Name: "table_a",
 				Columns: []*config.Column{
 					{
 						Name:          "col_1",
 						Type:          "int",
-						Order:         0,
+						Order:         9,
 						Precision:     0,
 						Unsigned:      false,
 						NotNull:       false,
@@ -185,19 +185,19 @@ func Test_BuildCreateTableStmt_Columns(t *testing.T) {
 				Charset: "utf8mb4",
 				Record:  100000,
 			},
-			sql: "CREATE TABLE IF NOT EXISTS table_a (\n    col_1 int(11)\n) DEFAULT CHARSET=utf8mb4",
+			sql: "CREATE TABLE IF NOT EXISTS table_a (\n    col_1 int(9)\n) DEFAULT CHARSET=utf8mb4",
 			err: nil,
 		},
 
 		{
-			name: "bigint(20)",
+			name: "bigint",
 			cfg: &config.Table{
 				Name: "table_a",
 				Columns: []*config.Column{
 					{
 						Name:          "col_1",
 						Type:          "bigint",
-						Order:         0,
+						Order:         11,
 						Precision:     0,
 						Unsigned:      false,
 						NotNull:       false,
@@ -211,7 +211,7 @@ func Test_BuildCreateTableStmt_Columns(t *testing.T) {
 				Charset: "utf8mb4",
 				Record:  100000,
 			},
-			sql: "CREATE TABLE IF NOT EXISTS table_a (\n    col_1 bigint(20)\n) DEFAULT CHARSET=utf8mb4",
+			sql: "CREATE TABLE IF NOT EXISTS table_a (\n    col_1 bigint(11)\n) DEFAULT CHARSET=utf8mb4",
 			err: nil,
 		},
 
@@ -223,7 +223,7 @@ func Test_BuildCreateTableStmt_Columns(t *testing.T) {
 					{
 						Name:          "col_1",
 						Type:          "bigint",
-						Order:         0,
+						Order:         20,
 						Precision:     0,
 						Unsigned:      true,
 						NotNull:       true,
@@ -244,39 +244,13 @@ func Test_BuildCreateTableStmt_Columns(t *testing.T) {
 		},
 
 		{
-			name: "decimal(10,0)",
+			name: "decimal",
 			cfg: &config.Table{
 				Name: "table_a",
 				Columns: []*config.Column{
 					{
 						Name:          "col_1",
 						Type:          "decimal",
-						Order:         0,
-						Precision:     0,
-						Unsigned:      false,
-						NotNull:       false,
-						Default:       nil,
-						Primary:       false,
-						AutoIncrement: false,
-						Values:        nilValues,
-					},
-				},
-				Indexes: []*config.Index{},
-				Charset: "utf8mb4",
-				Record:  100000,
-			},
-			sql: "CREATE TABLE IF NOT EXISTS table_a (\n    col_1 decimal(10, 0)\n) DEFAULT CHARSET=utf8mb4",
-			err: nil,
-		},
-
-		{
-			name: "float(5,2)",
-			cfg: &config.Table{
-				Name: "table_a",
-				Columns: []*config.Column{
-					{
-						Name:          "col_1",
-						Type:          "float",
 						Order:         5,
 						Precision:     2,
 						Unsigned:      false,
@@ -291,12 +265,38 @@ func Test_BuildCreateTableStmt_Columns(t *testing.T) {
 				Charset: "utf8mb4",
 				Record:  100000,
 			},
-			sql: "CREATE TABLE IF NOT EXISTS table_a (\n    col_1 float(5, 2)\n) DEFAULT CHARSET=utf8mb4",
+			sql: "CREATE TABLE IF NOT EXISTS table_a (\n    col_1 decimal(5, 2)\n) DEFAULT CHARSET=utf8mb4",
 			err: nil,
 		},
 
 		{
-			name: "real(5,2)",
+			name: "float",
+			cfg: &config.Table{
+				Name: "table_a",
+				Columns: []*config.Column{
+					{
+						Name:          "col_1",
+						Type:          "float",
+						Order:         10,
+						Precision:     0,
+						Unsigned:      false,
+						NotNull:       false,
+						Default:       nil,
+						Primary:       false,
+						AutoIncrement: false,
+						Values:        nilValues,
+					},
+				},
+				Indexes: []*config.Index{},
+				Charset: "utf8mb4",
+				Record:  100000,
+			},
+			sql: "CREATE TABLE IF NOT EXISTS table_a (\n    col_1 float(10, 0)\n) DEFAULT CHARSET=utf8mb4",
+			err: nil,
+		},
+
+		{
+			name: "real",
 			cfg: &config.Table{
 				Name: "table_a",
 				Columns: []*config.Column{
@@ -322,7 +322,7 @@ func Test_BuildCreateTableStmt_Columns(t *testing.T) {
 		},
 
 		{
-			name: "double(5,2)",
+			name: "double",
 			cfg: &config.Table{
 				Name: "table_a",
 				Columns: []*config.Column{
@@ -376,14 +376,14 @@ func Test_BuildCreateTableStmt_Columns(t *testing.T) {
 		},
 
 		{
-			name: "bit(1)",
+			name: "bit",
 			cfg: &config.Table{
 				Name: "table_a",
 				Columns: []*config.Column{
 					{
 						Name:          "col_1",
 						Type:          "bit",
-						Order:         0,
+						Order:         8,
 						Precision:     0,
 						Unsigned:      false,
 						NotNull:       false,
@@ -397,7 +397,7 @@ func Test_BuildCreateTableStmt_Columns(t *testing.T) {
 				Charset: "utf8mb4",
 				Record:  100000,
 			},
-			sql: "CREATE TABLE IF NOT EXISTS table_a (\n    col_1 bit(1)\n) DEFAULT CHARSET=utf8mb4",
+			sql: "CREATE TABLE IF NOT EXISTS table_a (\n    col_1 bit(8)\n) DEFAULT CHARSET=utf8mb4",
 			err: nil,
 		},
 
@@ -409,7 +409,7 @@ func Test_BuildCreateTableStmt_Columns(t *testing.T) {
 					{
 						Name:          "col_1",
 						Type:          "bit",
-						Order:         0,
+						Order:         1,
 						Precision:     0,
 						Unsigned:      true,
 						NotNull:       true,
@@ -751,7 +751,7 @@ func Test_BuildCreateTableStmt_Columns(t *testing.T) {
 					{
 						Name:          "col_1",
 						Type:          "blob",
-						Order:         65535,
+						Order:         100,
 						Precision:     0,
 						Unsigned:      false,
 						NotNull:       false,
@@ -765,7 +765,7 @@ func Test_BuildCreateTableStmt_Columns(t *testing.T) {
 				Charset: "utf8mb4",
 				Record:  100000,
 			},
-			sql: "CREATE TABLE IF NOT EXISTS table_a (\n    col_1 blob(65535)\n) DEFAULT CHARSET=utf8mb4",
+			sql: "CREATE TABLE IF NOT EXISTS table_a (\n    col_1 blob(100)\n) DEFAULT CHARSET=utf8mb4",
 			err: nil,
 		},
 
@@ -777,7 +777,7 @@ func Test_BuildCreateTableStmt_Columns(t *testing.T) {
 					{
 						Name:          "col_1",
 						Type:          "text",
-						Order:         65535,
+						Order:         100,
 						Precision:     0,
 						Unsigned:      false,
 						NotNull:       false,
@@ -791,7 +791,7 @@ func Test_BuildCreateTableStmt_Columns(t *testing.T) {
 				Charset: "utf8mb4",
 				Record:  100000,
 			},
-			sql: "CREATE TABLE IF NOT EXISTS table_a (\n    col_1 text(65535)\n) DEFAULT CHARSET=utf8mb4",
+			sql: "CREATE TABLE IF NOT EXISTS table_a (\n    col_1 text(100)\n) DEFAULT CHARSET=utf8mb4",
 			err: nil,
 		},
 
@@ -933,346 +933,6 @@ func Test_BuildCreateTableStmt_Columns(t *testing.T) {
 		sql := client.BuildCreateTableStmt(c.cfg)
 		if !assert.Equal(t, c.sql, sql) {
 			t.Errorf("case: %s is failed, expected: %+v, actual: %+v\n", c.name, c.sql, sql)
-		}
-	}
-}
-
-func Test_BuildOrderDesc(t *testing.T) {
-	cases := []struct {
-		name   string
-		cfg    *config.Column
-		result string
-		err    error
-	}{
-		{
-			name: "tinyint default",
-			cfg: &config.Column{
-				Name:          "col_1",
-				Type:          "tinyint",
-				Order:         0,
-				Precision:     0,
-				Unsigned:      false,
-				NotNull:       false,
-				Default:       nil,
-				Primary:       false,
-				AutoIncrement: false,
-			},
-			result: "(4)",
-			err:    nil,
-		},
-
-		{
-			name: "tinyint",
-			cfg: &config.Column{
-				Name:          "col_1",
-				Type:          "tinyint",
-				Order:         2,
-				Precision:     0,
-				Unsigned:      false,
-				NotNull:       false,
-				Default:       nil,
-				Primary:       false,
-				AutoIncrement: false,
-			},
-			result: "(2)",
-			err:    nil,
-		},
-
-		{
-			name: "smallint default",
-			cfg: &config.Column{
-				Name:          "col_1",
-				Type:          "smallint",
-				Order:         0,
-				Precision:     0,
-				Unsigned:      false,
-				NotNull:       false,
-				Default:       nil,
-				Primary:       false,
-				AutoIncrement: false,
-			},
-			result: "(6)",
-			err:    nil,
-		},
-
-		{
-			name: "smallint",
-			cfg: &config.Column{
-				Name:          "col_1",
-				Type:          "smallint",
-				Order:         4,
-				Precision:     0,
-				Unsigned:      false,
-				NotNull:       false,
-				Default:       nil,
-				Primary:       false,
-				AutoIncrement: false,
-			},
-			result: "(4)",
-			err:    nil,
-		},
-
-		{
-			name: "mediumint default",
-			cfg: &config.Column{
-				Name:          "col_1",
-				Type:          "mediumint",
-				Order:         0,
-				Precision:     0,
-				Unsigned:      false,
-				NotNull:       false,
-				Default:       nil,
-				Primary:       false,
-				AutoIncrement: false,
-			},
-			result: "(9)",
-			err:    nil,
-		},
-
-		{
-			name: "mediumint",
-			cfg: &config.Column{
-				Name:          "col_1",
-				Type:          "mediumint",
-				Order:         6,
-				Precision:     0,
-				Unsigned:      false,
-				NotNull:       false,
-				Default:       nil,
-				Primary:       false,
-				AutoIncrement: false,
-			},
-			result: "(6)",
-			err:    nil,
-		},
-
-		{
-			name: "int default",
-			cfg: &config.Column{
-				Name:          "col_1",
-				Type:          "int",
-				Order:         0,
-				Precision:     0,
-				Unsigned:      false,
-				NotNull:       false,
-				Default:       nil,
-				Primary:       false,
-				AutoIncrement: false,
-			},
-			result: "(11)",
-			err:    nil,
-		},
-
-		{
-			name: "int",
-			cfg: &config.Column{
-				Name:          "col_1",
-				Type:          "int",
-				Order:         9,
-				Precision:     0,
-				Unsigned:      false,
-				NotNull:       false,
-				Default:       nil,
-				Primary:       false,
-				AutoIncrement: false,
-			},
-			result: "(9)",
-			err:    nil,
-		},
-
-		{
-			name: "bigint default",
-			cfg: &config.Column{
-				Name:          "col_1",
-				Type:          "bigint",
-				Order:         0,
-				Precision:     0,
-				Unsigned:      false,
-				NotNull:       false,
-				Default:       nil,
-				Primary:       false,
-				AutoIncrement: false,
-			},
-			result: "(20)",
-			err:    nil,
-		},
-
-		{
-			name: "bigint",
-			cfg: &config.Column{
-				Name:          "col_1",
-				Type:          "bigint",
-				Order:         11,
-				Precision:     0,
-				Unsigned:      false,
-				NotNull:       false,
-				Default:       nil,
-				Primary:       false,
-				AutoIncrement: false,
-			},
-			result: "(11)",
-			err:    nil,
-		},
-
-		{
-			name: "bit default",
-			cfg: &config.Column{
-				Name:          "col_1",
-				Type:          "bit",
-				Order:         0,
-				Precision:     0,
-				Unsigned:      false,
-				NotNull:       false,
-				Default:       nil,
-				Primary:       false,
-				AutoIncrement: false,
-			},
-			result: "(1)",
-			err:    nil,
-		},
-
-		{
-			name: "bit",
-			cfg: &config.Column{
-				Name:          "col_1",
-				Type:          "bit",
-				Order:         8,
-				Precision:     0,
-				Unsigned:      false,
-				NotNull:       false,
-				Default:       nil,
-				Primary:       false,
-				AutoIncrement: false,
-			},
-			result: "(8)",
-			err:    nil,
-		},
-
-		{
-			name: "other default",
-			cfg: &config.Column{
-				Name:          "col_1",
-				Type:          "varchar",
-				Order:         0,
-				Precision:     0,
-				Unsigned:      false,
-				NotNull:       false,
-				Default:       nil,
-				Primary:       false,
-				AutoIncrement: false,
-			},
-			result: "(0)",
-			err:    nil,
-		},
-
-		{
-			name: "other",
-			cfg: &config.Column{
-				Name:          "col_1",
-				Type:          "varchar",
-				Order:         8,
-				Precision:     0,
-				Unsigned:      false,
-				NotNull:       false,
-				Default:       nil,
-				Primary:       false,
-				AutoIncrement: false,
-			},
-			result: "(8)",
-			err:    nil,
-		},
-	}
-
-	for _, c := range cases {
-		client := database.MySQLClient{}
-		result := client.BuildOrderDesc(c.cfg)
-		if !assert.Equal(t, c.result, result) {
-			t.Errorf("case: %s is failed, expected: %+v, actual: %+v\n", c.name, c.result, result)
-		}
-	}
-}
-
-func Test_BuildPrecisionDesc(t *testing.T) {
-	cases := []struct {
-		name   string
-		cfg    *config.Column
-		result string
-		err    error
-	}{
-		{
-			name: "decimal default",
-			cfg: &config.Column{
-				Name:          "col_1",
-				Type:          "decimal",
-				Order:         0,
-				Precision:     0,
-				Unsigned:      false,
-				NotNull:       false,
-				Default:       nil,
-				Primary:       false,
-				AutoIncrement: false,
-			},
-			result: "(10, 0)",
-			err:    nil,
-		},
-
-		{
-			name: "decimal",
-			cfg: &config.Column{
-				Name:          "col_1",
-				Type:          "decimal",
-				Order:         6,
-				Precision:     3,
-				Unsigned:      false,
-				NotNull:       false,
-				Default:       nil,
-				Primary:       false,
-				AutoIncrement: false,
-			},
-			result: "(6, 3)",
-			err:    nil,
-		},
-
-		{
-			name: "other default",
-			cfg: &config.Column{
-				Name:          "col_1",
-				Type:          "float",
-				Order:         0,
-				Precision:     0,
-				Unsigned:      false,
-				NotNull:       false,
-				Default:       nil,
-				Primary:       false,
-				AutoIncrement: false,
-			},
-			result: "(0, 0)",
-			err:    nil,
-		},
-
-		{
-			name: "other",
-			cfg: &config.Column{
-				Name:          "col_1",
-				Type:          "float",
-				Order:         6,
-				Precision:     3,
-				Unsigned:      false,
-				NotNull:       false,
-				Default:       nil,
-				Primary:       false,
-				AutoIncrement: false,
-			},
-			result: "(6, 3)",
-			err:    nil,
-		},
-	}
-
-	for _, c := range cases {
-		client := database.MySQLClient{}
-		result := client.BuildPrecisionDesc(c.cfg)
-		if !assert.Equal(t, c.result, result) {
-			t.Errorf("case: %s is failed, expected: %+v, actual: %+v\n", c.name, c.result, result)
 		}
 	}
 }

--- a/examples/minimal_from_create_table.yaml
+++ b/examples/minimal_from_create_table.yaml
@@ -15,7 +15,6 @@ tables:
       autoIncrement: true
     - name: col_2
       type: varchar
-      order: 50
       notNull: true
     - name: col_3
       type: boolean
@@ -23,8 +22,6 @@ tables:
       notNull: true
     - name: col_4
       type: float
-      order: 5
-      precision: 3
       notNull: true
     - name: col_5
       type: decimal
@@ -50,7 +47,6 @@ tables:
       notNull: true
     - name: col_3
       type: varchar
-      order: 20
       default: ""
       values:
         - "NotYet"

--- a/examples/minimal_only_populate_seed.yaml
+++ b/examples/minimal_only_populate_seed.yaml
@@ -14,13 +14,10 @@ tables:
       autoIncrement: true
     - name: col_2
       type: varchar
-      order: 50
     - name: col_3
       type: boolean
     - name: col_4
       type: float
-      order: 5
-      precision: 3
     - name: col_5
       type: decimal
   charset: utf8mb4
@@ -35,7 +32,6 @@ tables:
       type: datetime
     - name: col_3
       type: varchar
-      order: 20
       values:
         - "NotYet"
         - "Doing"


### PR DESCRIPTION
# Summary
In many usecase, inspecting sql query, we don't focus on data type order/precision.
So, I add default order/presicion even those data-types are officially not supported in terms of default order/presicion by RDBMS (this time MySQL)