### PR TITLE
Tuning resource use

### DIFF
--- a/README.md
+++ b/README.md
@@ -267,16 +267,82 @@ When you want to use covering index, you can describe like below.
 There're sample config files, you can try it.
 
 when you haven't setup the database or tables yet
+
 ```shell
 $ populator -c ./examples/from_create_table.yaml
 ```
 
 when you've already setup the database and tables
+
 ```shell
 $ populator -c ./examples/only_populate_seed.yaml
 ```
 
 when you want to re-create table schema w/ given declarations
+
 ```shell
 $ populator -rc ./examples/from_create_table.yaml
+```
+
+## Tips
+For populating Database w/ a large amount of seed data, you can change some parameters. Here's some examples.
+
+### Error 1040: Too many connections
+When populator returns below log, you might improve situation by changing max_connections.
+
+```sql
+-- current config
+mysql> show variables like "%max_connections%";
++-----------------+-------+
+| Variable_name   | Value |
++-----------------+-------+
+| max_connections | 151   |
++-----------------+-------+
+1 row in set (5.39 sec)
+
+-- actual conenction
+mysql> select count(*) from information_schema.PROCESSLIST;
++----------+
+| count(*) |
++----------+
+|      152 |
++----------+
+1 row in set (0.12 sec)
+
+-- change config
+mysql> set global max_connections = 700;
+Query OK, 0 rows affected (0.02 sec)
+
+mysql> select count(*) from information_schema.PROCESSLIST;
++----------+
+| count(*) |
++----------+
+|      697 |
++----------+
+1 row in set (0.02 sec)
+```
+
+### dial tcp 127.0.0.1:3306: socket: too many open files
+When populator returns below log, you might improve situation by changing ulimit.
+
+For MacOS
+```shell
+$ ulimit -n
+256
+
+$ ulimit -n 4800
+$ ulimit -n
+4800
+```
+
+For Linux
+```shell
+$ vi /etc/security/limits.conf
+* soft nofile 4800
+* hard nofile 4800
+
+<reboot>
+
+$ sudo ulimit -n
+4800
 ```

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -84,6 +84,8 @@ func init() {
 
 	rootCmd.PersistentFlags().BoolVarP(&reCreate, "recreate", "r", false, "drop tables then create them from scratch")
 
+	rootCmd.PersistentFlags().BoolVarP(&database.Verbose, "verbose", "v", false, "show executed sql")
+
 	rootCmd.DisableSuggestions = true
 }
 

--- a/database/mysql_connector.go
+++ b/database/mysql_connector.go
@@ -27,6 +27,9 @@ import (
 	"github.com/terakoya76/populator/config"
 )
 
+// MaxConnections holds max_connections var for memory use control
+var MaxConnections int
+
 // MySQLConnector is an implementation of DBConnector for MySQL
 type MySQLConnector struct{}
 
@@ -53,6 +56,12 @@ func (c *MySQLConnector) Connect(cfg *config.Database) (DBClient, error) {
 	db, err = sqlx.Connect("mysql", ci+cfg.Name)
 	if err != nil {
 		return nil, fmt.Errorf("failed to setup database %s on mysql: %+v", cfg.Name, err)
+	}
+
+	var _name string
+	err = db.QueryRow("show variables like \"%max_connections%\"").Scan(&_name, &MaxConnections)
+	if err != nil {
+		fmt.Println(err)
 	}
 
 	return &MySQLClient{db}, nil

--- a/utils/utils.go
+++ b/utils/utils.go
@@ -26,20 +26,3 @@ func Contains(s []interface{}, e interface{}) bool {
 	}
 	return false
 }
-
-// BatchTimes executes a given func w/ batch iteration until reaching the given times
-func BatchTimes(batchFn func([]string) error, valueFn func() string, times int, batchSize int) error {
-	slice := make([]string, times)
-
-	for i := 0; i < times; i += batchSize {
-		for j := 0; j < batchSize; j++ {
-			row := valueFn()
-			slice[i+j] = row
-		}
-		if err := batchFn(slice[i : i+batchSize]); err != nil {
-			return err
-		}
-	}
-
-	return nil
-}


### PR DESCRIPTION
# Summary
Current implementation is really resource consuming.
When I gave populator a config w/ `record: 100000000000`, it always got OOM.

So, I refined implementation.
On the other hand, populator seems to leave cpu resource, so introduce go-routine for the concurrency